### PR TITLE
pull key master changes into virtualize

### DIFF
--- a/antelope_core/archives/basic_archive.py
+++ b/antelope_core/archives/basic_archive.py
@@ -377,6 +377,7 @@ class BasicArchive(EntityStore):
         q_map = dict()
         if 'quantities' in j:
             for e in j['quantities']:
+                e['entityType'] = 'quantity'
                 q = self.entity_from_json(e)
                 if q.uuid is not None:
                     q_map[q.uuid] = q
@@ -386,6 +387,7 @@ class BasicArchive(EntityStore):
 
         if 'flows' in j:
             for e in j['flows']:
+                e['entityType'] = 'flow'
                 self.entity_from_json(e)
 
         if 'loaded' in j:

--- a/antelope_core/archives/quantity_manager.py
+++ b/antelope_core/archives/quantity_manager.py
@@ -74,8 +74,11 @@ class QuantitySynonyms(SynonymSet):
     def add_child(self, other, force=False):
         if not isinstance(other, QuantitySynonyms):
             raise TypeError('Child set is not a Quantity synonym set (%s)' % type(other))
-        if other.unit is not None and other.unit != self.unit:
-            raise QuantityUnitMismatch('incoming %s (canonical %s)' % (other.unit, self._quantity.unit))
+        if other.unit is not None:
+            if self.unit is None:
+                self._unit = other.unit
+            elif other.unit != self.unit:
+                raise QuantityUnitMismatch('incoming %s (canonical %s)' % (other.unit, self._quantity.unit))
         if self._quantity is None:
             self.quantity = other.quantity
         elif self._quantity.is_entity:

--- a/antelope_core/archives/quantity_manager.py
+++ b/antelope_core/archives/quantity_manager.py
@@ -22,10 +22,11 @@ class QuantitySynonyms(SynonymSet):
     LciaEngine should be able to handle conversions between these kinds of quantities.
     """
 
-    def _check_incoming_unit(self, unit):
+    def _check_incoming_unit(self, quantity):
+        unit = quantity.unit
         if unit is None:
             return
-        if not isinstance(quantity.unit, str):
+        if not isinstance(unit, str):
             raise AttributeError(quantity, 'unit-str')
         if self._unit is None:
             if unit is not None:
@@ -53,7 +54,7 @@ class QuantitySynonyms(SynonymSet):
             raise TypeError(quantity)
         if not hasattr(quantity, 'unit'):
             raise AttributeError(quantity, 'unit')
-        self._check_incoming_unit(quantity.unit)
+        self._check_incoming_unit(quantity)
         return True
 
     def __init__(self, *args, quantity=None, unit=None, **kwargs):
@@ -92,7 +93,7 @@ class QuantitySynonyms(SynonymSet):
     def add_child(self, other, force=False):
         if not isinstance(other, QuantitySynonyms):
             raise TypeError('Child set is not a Quantity synonym set (%s)' % type(other))
-        self._check_incoming_unit(other.unit)
+        self._check_incoming_unit(other)
         if self._quantity is None:
             self.quantity = other.quantity
         elif self._quantity.is_entity:

--- a/antelope_core/catalog/catalog.py
+++ b/antelope_core/catalog/catalog.py
@@ -22,7 +22,7 @@ From the catalog_ref file, the catalog should meet the following spec:
 """
 
 import os
-import re
+# import re
 import hashlib
 # from collections import defaultdict
 
@@ -30,7 +30,7 @@ from ..archives import InterfaceError
 from ..lcia_engine import LciaDb
 
 
-from antelope import CatalogRef, UnknownOrigin
+from antelope import CatalogRef, UnknownOrigin, EntityNotFound
 from ..catalog_query import CatalogQuery, INTERFACE_TYPES, zap_inventory
 from .lc_resolver import LcCatalogResolver
 from ..lc_resource import LcResource
@@ -405,6 +405,6 @@ class StaticCatalog(object):
         try:
             q = self.query(origin)
             ref = q.get(external_ref)
-        except UnknownOrigin:
+        except (UnknownOrigin, EntityNotFound):
             ref = CatalogRef(origin, external_ref, entity_type=entity_type, **kwargs)
         return ref

--- a/antelope_core/catalog/catalog.py
+++ b/antelope_core/catalog/catalog.py
@@ -30,7 +30,7 @@ from ..archives import InterfaceError
 from ..lcia_engine import LciaDb
 
 
-from antelope import CatalogRef, UnknownOrigin, EntityNotFound
+from antelope import CatalogRef, UnknownOrigin  # , EntityNotFound
 from ..catalog_query import CatalogQuery, INTERFACE_TYPES, zap_inventory
 from .lc_resolver import LcCatalogResolver
 from ..lc_resource import LcResource
@@ -404,7 +404,9 @@ class StaticCatalog(object):
         """
         try:
             q = self.query(origin)
-            ref = q.get(external_ref)
-        except (UnknownOrigin, EntityNotFound):
-            ref = CatalogRef(origin, external_ref, entity_type=entity_type, **kwargs)
-        return ref
+        except UnknownOrigin:
+            return CatalogRef(origin, external_ref, entity_type=entity_type, **kwargs)
+        return q.get(external_ref)
+        # except EntityNotFound:  why would we catch this?
+        #     return CatalogRef.from_query(external_ref, q, entity_type=entity_type, **kwargs)
+

--- a/antelope_core/lc_resource.py
+++ b/antelope_core/lc_resource.py
@@ -168,6 +168,7 @@ class LcResource(object):
     def check(self, catalog):
         if self._archive is None:
             # TODO: try/catch exceptions or return false
+            # print('QQQQQQQQQQQQQQQQQQ %s QQQQQQQQQQQQQQQQQQ' % self.reference)
             self._instantiate(catalog)
             self.apply_config(catalog)  # can't remember why I set this to happen recurrently- but it's no good
         return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 synonym_dict>=0.2.0
-antelope_interface>=0.1.7
+git+git://github.com/AntelopeLCA/antelope@master#egg=antelope_interface
 xlrd==1.2.0
 python-magic>=0.4.18
 requests>=2.25


### PR DESCRIPTION
quantities should be able to be underspecified
normalize entity types in deserialization
shouldn't catch entity not found on catalog ref creation